### PR TITLE
Added emoji feature to the chat input section

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "emoji-picker-react": "^3.4.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",

--- a/frontend/src/components/common/chatInput.tsx
+++ b/frontend/src/components/common/chatInput.tsx
@@ -1,22 +1,38 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
+
+import Picker from "emoji-picker-react";
 
 import chatEmoji from "../../media/chatEmoji.svg";
 import chatSend from "../../media/chatSend.svg";
 import chatGif from "../../media/chatGif.svg";
 
 function ChatInput() {
+  const [inputStr, setInputStr] = useState("");
+  const [showPicker, setShowPicker] = useState(false);
+
+  const onEmojiClick = (event, emojiObject) => {
+    setInputStr((prevInput) => prevInput + emojiObject.emoji);
+    setShowPicker(false);
+    
+  };
   return (
     <Wrapper>
       <input
         type="text"
         className="chat-input"
         placeholder="Type a message..."
+        value={inputStr}
+        onChange={(e) => setInputStr(e.target.value)}
       />
       <div className="chat-icon-group">
-        <img src={chatEmoji} alt="emoji" className="chat-icon" />
+        <img src={chatEmoji} alt="emoji" className="chat-icon" onClick={() => setShowPicker((val) => !val)}/>
+        {showPicker && (
+          <Picker pickerStyle={{ width: "100%" }} onEmojiClick={onEmojiClick} />
+        )}
         <img src={chatGif} alt="gif" className="chat-icon" />
         <img src={chatSend} alt="send" className="chat-icon" />
+       
       </div>
     </Wrapper>
   );

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4500,6 +4500,11 @@ emittery@^0.7.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
   integrity sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
 
+emoji-picker-react@^3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/emoji-picker-react/-/emoji-picker-react-3.4.8.tgz#6d3365a3447f9bb8b39ec1a007cdef39553d3810"
+  integrity sha512-HsKsompl0zThl1jhLaRPHnn0MdPVs9AxJRa5KM7OVnteoCx/tNr9iMipC2rI2vAMkKstlkedirswUwKAu2AsDg==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
User Story:  As a user, I would like to be able to send emojis along with my texts when in the chat area.

Workflow: 

1. Click on the chat input section.
2. Input my desired text/comments to send in the chat comment section.
3. Click on the emoji button to select an emoji of my choice while typing.

Collaborators:
UI/UX Designer - Imhade
Frontend Developer - Taofiq