### PR TITLE
Clear pasteUrl Input Field upon Submission

### DIFF
--- a/server/client/src/components/common/pasteUrl.tsx
+++ b/server/client/src/components/common/pasteUrl.tsx
@@ -28,7 +28,9 @@ const PasteUrl = (props: Props) => {
   const handleSubmit = async (e: any) => {
     e.preventDefault();
 
-    if (props.getSongByUrl(url)) return toast.error("The song already exist.");
+    if (props.getSongByUrl(url)) {
+      return toast.error("This song already exists.") && setUrl("");
+    }
 
     uiDispatch.loading(true);
 
@@ -37,6 +39,10 @@ const PasteUrl = (props: Props) => {
       await songService.addSongbyUrl(url);
       uiDispatch.showPasteUrl(false);
       toast.success("Added Successfully");
+
+      // this.setState(url: "");
+      setUrl("");
+
     } catch (e) {
       toast.error(e.message);
     }


### PR DESCRIPTION
Set the pasteUrl input field to automatically clear upon successful submission or if the error of the song already existing comes up.
For other errors, the input field is not cleared, so that the user can correct the error just in case it's minor, instead of having to enter the URL all over again.