### PR TITLE
Set Playlist Header to stop appearing under Songs while scrolling

### DIFF
--- a/server/client/src/components/common/playlistHeader.tsx
+++ b/server/client/src/components/common/playlistHeader.tsx
@@ -87,6 +87,7 @@ const Wrapper = styled.div`
   justify-content: center;
   width: 100%;
   overflow: hidden;
+  z-index: 11111111;
 
   .playlist-content-wrapper {
     display: flex;

--- a/server/client/src/components/common/playlistItems.tsx
+++ b/server/client/src/components/common/playlistItems.tsx
@@ -2,18 +2,24 @@ import Song from "../../types/song";
 
 import PlaylistItem from "./playlistItem";
 
+import styled from 'styled-components';
+
 interface Props {
   songs: Song[];
 }
 
 function PlaylistItems({ songs }: Props) {
   return (
-    <div className="playlist-item-group" style={{ paddingBottom: "10px" }}>
+    <Wrapper className="playlist-item-group" style={{ paddingBottom: "10px" }}>
       {songs.map((song, index) => (
         <PlaylistItem key={index} song={song} />
       ))}
-    </div>
+    </Wrapper>
   );
 }
+
+const Wrapper = styled.div`
+  background: white;
+`
 
 export default PlaylistItems;

--- a/server/client/src/components/roomHeader.tsx
+++ b/server/client/src/components/roomHeader.tsx
@@ -83,8 +83,8 @@ const roomHeader = () => {
 };
 
 const Wrapper = styled.header`
-  position: sticky;
-  top: -1px;
+  position: fixed;
+  top: 5px;
   left: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Setup the playlist items to scroll under the playlist header, fixing the bug that made the playlist header appear under the songs while scrolling.