### PR TITLE
fix for the like song by user endpoint.

### DIFF
--- a/server/music/serializers.py
+++ b/server/music/serializers.py
@@ -42,9 +42,8 @@ class SongSerializer(serializers.Serializer):
 
 class LikeSongSerializer(serializers.Serializer):
     song_id = serializers.CharField(max_length=100, required=False)
-    memberId = serializers.ListField(
-        child=serializers.CharField(max_length=100), allow_empty=False
-    )
+    memberId = serializers.CharField(max_length=100, required=False)
+
 
 
 class SongLikeCountSerializer(serializers.Serializer):


### PR DESCRIPTION
When the endpoint is called, the userid and songid is also sent, we get the song information using the songid then append the user id to the likedby array of the song object.
Each userid added to the array is unique meaning a user can only like a song once. 
This is a sample of the post data.

`{"song_id":"616b18fd11879e46e6c8ba33","memberId":"123"}`

Like Songs Endpoint - http://music.zuri.chat/music/api/v1/org/str:org_id/room/str:_id/songs/like